### PR TITLE
feat(hub ux): bindings, status probe fallbacks, log+toast, safe pins, build scripts

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -1,5 +1,5 @@
-
-# Build Windows exe with PyInstaller
+@echo off
+REM Build Windows exe with PyInstaller
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install pyinstaller


### PR DESCRIPTION
## Summary
- enhance QML header with drag, tooltips, log toggle and toast notifications
- add robust binary probing for Tesseract/ImageMagick and pass env from Bridge
- harden pin storage and add scripts/ to Windows build outputs

## Testing
- `python -m py_compile app.py core/bincheck.py core/config.py core/process.py`

------
https://chatgpt.com/codex/tasks/task_e_6896fe7c327c8321b2212f5e34591027