### PR TITLE
fix: drag header startSystemMove(), PowerShell continuations, ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 .env
+build/
+dist/
+*.spec

--- a/build_win.ps1
+++ b/build_win.ps1
@@ -3,7 +3,7 @@
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install pyinstaller
-pyinstaller app.py -n OverlayRouter -w ^
-  --hidden-import PySide6.QtQml --hidden-import PySide6.QtGui --hidden-import PySide6.QtWidgets ^
-  --collect-all PySide6 --collect-submodules PySide6 ^
+pyinstaller app.py -n OverlayRouter -w `
+  --hidden-import PySide6.QtQml --hidden-import PySide6.QtGui --hidden-import PySide6.QtWidgets `
+  --collect-all PySide6 --collect-submodules PySide6 `
   --add-data "ui;ui" --add-data "assets;assets" --add-data "config;config" --add-data "scripts;scripts"

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -73,7 +73,11 @@ Window {
                         property string key: modelData
                         color: stateColor(root.statuses[key].state)
                         MouseArea { id: ma; anchors.fill: parent; hoverEnabled: true }
-                        ToolTip { visible: ma.containsMouse; text: root.statuses[key].version }
+                        ToolTip {
+                            visible: ma.containsMouse
+                            text: root.statuses[key].version
+                            padding: 6
+                        }
                     }
                 }
 
@@ -90,7 +94,11 @@ Window {
                 }
                 Button { text: "Close"; onClicked: Qt.quit() }
             }
-            MouseArea { anchors.fill: parent; z: -1; onPressed: root.startSystemMove(mouse) }
+            MouseArea {
+                anchors.fill: parent
+                z: 999
+                onPressed: root.startSystemMove()
+            }
         }
 
         Flow {


### PR DESCRIPTION
## Summary
- raise header MouseArea z and call startSystemMove without args
- use PowerShell backticks for line continuation
- ignore build artifacts: build/, dist/, spec files

## Testing
- `python app.py` *(fails: ImportError: libGL.so.1)*
- `pwsh -NoLogo -Command "Get-Host"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970162813883219c3a3020ddb15f3f