### PR TITLE
feat(kb): add optional Ken Burns integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Edytuj `config/actions.yaml`. Obsługiwane pola:
 
 Po zmianie w YAML kliknij **Reload** w panelu.
 
+## Ken Burns (opcjonalny moduł)
+
+Funkcjonalność Ken Burns jest w pełni opcjonalna. Aby ją włączyć:
+
+1. Zainstaluj moduł `ken_burns_reel` oraz upewnij się, że `ffmpeg` jest dostępny w `PATH`.
+2. Ustaw zmienną środowiskową `KENBURNS_ENABLED=1` przed uruchomieniem aplikacji.
+
+Po spełnieniu warunków w UI pojawi się przycisk **Ken Burns...** otwierający dialog z prostym formularzem uruchamiającym CLI.
+
+Aby wyłączyć moduł, usuń zmienną `KENBURNS_ENABLED` i zrestartuj aplikację.
+
 ## Build EXE (Windows)
 ```powershell
 .\build_win.ps1

--- a/plugins/kenburns/KenBurnsTab.qml
+++ b/plugins/kenburns/KenBurnsTab.qml
@@ -1,0 +1,77 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+Item {
+    width: 480
+    height: 320
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 8
+        padding: 8
+
+        TextField {
+            id: argField
+            placeholderText: "--help"
+            Layout.fillWidth: true
+        }
+
+        RowLayout {
+            Button {
+                text: "Run"
+                onClicked: KenBurns.run(argField.text)
+            }
+            Button {
+                text: "Stop"
+                onClicked: KenBurns.stop()
+            }
+            Button {
+                text: "Save preset"
+                onClicked: KenBurns.savePreset("custom_preset.json", argField.text)
+            }
+        }
+
+        TextArea {
+            id: logArea
+            readOnly: true
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+
+    Connections {
+        target: KenBurns
+        function onOutput(msg) {
+            logArea.append(msg)
+            logArea.cursorPosition = logArea.length
+        }
+        function onFinished(code) {
+            toast.text = code === 0 ? "Process finished" : "Process failed";
+            toast.color = code === 0 ? "#444444" : "#E74C3C";
+            toast.visible = true;
+            logArea.append("[EXIT] " + code)
+            logArea.cursorPosition = logArea.length
+        }
+    }
+
+    Rectangle {
+        id: toast
+        property string text: ""
+        width: parent.width
+        height: 30
+        anchors.bottom: parent.bottom
+        color: "#444444"
+        visible: opacity > 0
+        opacity: 0
+        Text { anchors.centerIn: parent; color: "white"; text: parent.text }
+        Behavior on opacity { NumberAnimation { duration: 200 } }
+        Timer { id: toastTimer; interval: 2000; onTriggered: toast.opacity = 0 }
+        function show(msg, ok) {
+            text = msg
+            color = ok ? "#444444" : "#E74C3C"
+            opacity = 1
+            toastTimer.restart()
+        }
+    }
+}

--- a/plugins/kenburns/plugin_kenburns.py
+++ b/plugins/kenburns/plugin_kenburns.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+import sys
+from pathlib import Path
+from PySide6.QtCore import QObject, Signal, Slot, QProcess
+from core.process import ProcessRunner
+
+class KenBurnsBridge(QObject):
+    """Minimal bridge to run ken_burns_reel in a separate process."""
+
+    output = Signal(str)
+    finished = Signal(int)
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+        self._runner = ProcessRunner()
+        self._runner.output.connect(self.output)
+        self._runner.finished.connect(self.finished)
+
+    @Slot(str)
+    def run(self, args: str) -> None:
+        cmd = f'"{sys.executable}" -m ken_burns_reel {args}'.strip()
+        self._runner.run(cmd)
+
+    @Slot()
+    def stop(self) -> None:
+        proc = self._runner.proc
+        if proc and proc.state() != QProcess.NotRunning:
+            proc.kill()
+            proc.waitForFinished(1000)
+
+    @Slot(str, str, result=bool)
+    def savePreset(self, filename: str, args: str) -> bool:
+        """Save given args string to a JSON file near executable.
+
+        Returns True on success.
+        """
+        try:
+            import json
+            base = Path(sys.argv[0]).resolve().parent
+            path = base / filename
+            tmp = path.with_suffix('.tmp')
+            tmp.write_text(json.dumps({"args": args}))
+            tmp.replace(path)
+            return True
+        except Exception:
+            return False

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -88,6 +88,12 @@ Window {
                     onClicked: Bridge.toggleClickThrough()
                 }
                 Button {
+                    id: kbBtn
+                    text: "Ken Burns..."
+                    visible: HasKenBurns
+                    onClicked: kbDialog.open()
+                }
+                Button {
                     id: logBtn
                     text: logPanel.visible ? "Hide Log" : "Show Log"
                     onClicked: logPanel.visible = !logPanel.visible
@@ -189,6 +195,20 @@ Window {
         Timer { id: toastTimer; interval: toast.timeout; onTriggered: toast.opacity = 0 }
         function show(msg, t) {
             text = msg; type = t || "info"; opacity = 1; toastTimer.restart();
+        }
+    }
+
+    Dialog {
+        id: kbDialog
+        modal: true
+        visible: false
+        standardButtons: Dialog.Close
+        onClosed: kbLoader.active = false
+        Loader {
+            id: kbLoader
+            anchors.fill: parent
+            active: visible && HasKenBurns
+            source: HasKenBurns ? "plugins/kenburns/KenBurnsTab.qml" : ""
         }
     }
 


### PR DESCRIPTION
## Summary
- gate Ken Burns module behind `KENBURNS_ENABLED` and dependency checks
- expose KenBurnsBridge for running `ken_burns_reel` and wire it into a dialog UI
- document optional Ken Burns usage in README

## Testing
- `python -m py_compile app.py plugins/kenburns/plugin_kenburns.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897789606548321888e234ef85753ee