### PR TITLE
feat: enhance ken burns dialog and ffmpeg check

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Po spełnieniu warunków w UI pojawi się przycisk **Ken Burns...** otwierający
 
 Aby wyłączyć moduł, usuń zmienną `KENBURNS_ENABLED` i zrestartuj aplikację.
 
+### Przykładowe komendy (w polu "Args")
+- One-Click Preview: `--oneclick --profile preview`
+- Overlay z rozmytym tłem (social): `--mode panels-overlay --bg-source blur --profile social`
+- Eksport paneli (rect): `--export-panels panels --export-mode rect`
+*(Pamiętaj o ustawieniu pola "Folder" — domyślnie bieżący `.`)*
+
 ## Build EXE (Windows)
 ```powershell
 .\build_win.ps1

--- a/app.py
+++ b/app.py
@@ -140,6 +140,7 @@ class Bridge(QObject):
         self._statuses = {
             "magick": {"state": "unknown", "version": ""},
             "tesseract": {"state": "unknown", "version": ""},
+            "ffmpeg": {"state": "unknown", "version": ""},
             "n8n": {"state": "unknown", "version": "not set"},
         }
         self._load_pinned()
@@ -385,6 +386,7 @@ if __name__ == "__main__":
             print(f"[WARN] Ken Burns bridge load failed: {e}")
             has_kb = False
             engine.rootContext().setContextProperty("HasKenBurns", False)
+            engine.rootContext().setContextProperty("KenBurns", None)
 
     runner = ProcessRunner()
     bridge = Bridge(runner, engine)

--- a/core/bincheck.py
+++ b/core/bincheck.py
@@ -62,6 +62,7 @@ def probe_status(actions: list[dict], env: dict | None = None) -> dict:
     status = {
         "magick": {"state": "unknown", "version": ""},
         "tesseract": {"state": "unknown", "version": ""},
+        "ffmpeg": {"state": "unknown", "version": ""},
         "n8n": {"state": "unknown", "version": "not set"},
     }
 
@@ -101,6 +102,16 @@ def probe_status(actions: list[dict], env: dict | None = None) -> dict:
         }
     else:
         status["tesseract"] = {"state": "fail", "version": ""}
+
+    # --- ffmpeg ---
+    if shutil.which("ffmpeg"):
+        ok, text = _version_ok(["ffmpeg", "-version"])
+        status["ffmpeg"] = {
+            "state": "ok" if ok else "warn",
+            "version": text.splitlines()[0] if text else "",
+        }
+    else:
+        status["ffmpeg"] = {"state": "fail", "version": ""}
 
     # --- n8n ---
     if env.get("N8N_WEBHOOK_PING"):

--- a/plugins/kenburns/KenBurnsTab.qml
+++ b/plugins/kenburns/KenBurnsTab.qml
@@ -11,6 +11,28 @@ Item {
         spacing: 8
         padding: 8
 
+        RowLayout {
+            Label { text: "Folder:" }
+            TextField {
+                id: folderField
+                placeholderText: "."
+                text: "."
+                Layout.fillWidth: true
+            }
+            Button {
+                text: "--help"
+                ToolTip.text: "Wstaw --help do pola argów"
+                onClicked: argField.text = "--help"
+            }
+        }
+
+        RowLayout {
+            spacing: 6
+            Button { text: "Preview"; onClicked: argField.text = "--oneclick --profile preview" }
+            Button { text: "Overlay Blur"; onClicked: argField.text = "--mode panels-overlay --bg-source blur --profile social" }
+            Button { text: "Export Panels"; onClicked: argField.text = "--export-panels panels --export-mode rect" }
+        }
+
         TextField {
             id: argField
             placeholderText: "--help"
@@ -20,7 +42,12 @@ Item {
         RowLayout {
             Button {
                 text: "Run"
-                onClicked: KenBurns.run(argField.text)
+                onClicked: {
+                    const folder = (folderField.text || ".").trim();
+                    const args = argField.text.trim();
+                    const full = `"${folder.replace(/"/g, '\\"')}"` + (args ? " " + args : "");
+                    KenBurns.run(full);
+                }
             }
             Button {
                 text: "Stop"
@@ -28,7 +55,10 @@ Item {
             }
             Button {
                 text: "Save preset"
-                onClicked: KenBurns.savePreset("custom_preset.json", argField.text)
+                onClicked: {
+                    const ok = KenBurns.savePreset("custom_preset.json", argField.text);
+                    toast.show(ok ? "Preset saved" : "Save failed", ok);
+                }
             }
         }
 
@@ -47,11 +77,10 @@ Item {
             logArea.cursorPosition = logArea.length
         }
         function onFinished(code) {
-            toast.text = code === 0 ? "Process finished" : "Process failed";
-            toast.color = code === 0 ? "#444444" : "#E74C3C";
-            toast.visible = true;
-            logArea.append("[EXIT] " + code)
-            logArea.cursorPosition = logArea.length
+            if (code === 0) toast.show("Process finished", true);
+            else toast.show("Process failed (" + code + ")", false);
+            logArea.append("[EXIT] " + code);
+            logArea.cursorPosition = logArea.length;
         }
     }
 

--- a/plugins/kenburns/plugin_kenburns.py
+++ b/plugins/kenburns/plugin_kenburns.py
@@ -25,8 +25,10 @@ class KenBurnsBridge(QObject):
     def stop(self) -> None:
         proc = self._runner.proc
         if proc and proc.state() != QProcess.NotRunning:
-            proc.kill()
-            proc.waitForFinished(1000)
+            proc.terminate()
+            if not proc.waitForFinished(1500):
+                proc.kill()
+                proc.waitForFinished(1000)
 
     @Slot(str, str, result=bool)
     def savePreset(self, filename: str, args: str) -> bool:

--- a/ui/Main.qml
+++ b/ui/Main.qml
@@ -67,7 +67,7 @@ Window {
                 }
 
                 Repeater {
-                    model: ["magick","tesseract","n8n"]
+                    model: ["magick","tesseract","ffmpeg","n8n"]
                     delegate: Rectangle {
                         width: 10; height: 10; radius: 5
                         property string key: modelData


### PR DESCRIPTION
## Summary
- add folder field, presets, and toasts for Ken Burns dialog
- terminate ffmpeg processes gracefully and expose bridge failures safely
- probe ffmpeg availability and surface status indicator in UI

## Testing
- `python -m py_compile app.py core/bincheck.py plugins/kenburns/plugin_kenburns.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68977c67adb48321a2dd60da1e2d7262